### PR TITLE
fix of issue #13 (import failure due to failure to detect delimiter) and another possible bug (originating in revtools).

### DIFF
--- a/R/prep_ris.R
+++ b/R/prep_ris.R
@@ -82,7 +82,7 @@ detect_delimiter <- function (x)
   else {
     char_list <- strsplit(x, "")
     char_break_test <- unlist(lapply(char_list, function(a) {
-      length(unique(a)) == 1 & length(a > 6)
+      length(unique(a)) == 1 & length(a) > 6
     }))
     if (any(char_break_test)) {
       delimiter <- "character"

--- a/R/read_bibliography.R
+++ b/R/read_bibliography.R
@@ -38,7 +38,7 @@ read_bibliography<- function (filename = NULL, return_df = TRUE,refChars = NULL)
   } else{
     stop("Please provide a valid file path 'filename' or character vector 'refChars' to be converted to a bibliography.")
   }
-  nrows <- min(c(200, length(z)))
+  nrows <- min(c(300, length(z)))
   zsub <- z[seq_len(nrows)]
   tag_type <- "ris"
   z_dframe <- prep_ris(z, detect_delimiter(zsub))

--- a/searchbuildR.Rproj
+++ b/searchbuildR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ebf653d9-1c6f-4c02-a637-6c8e350302fb
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
This small change fixes an issue where the delimiter between the datasets in the import file is not located in the first 200 lines of text. The current commit increases the number of lines from 200 to 300, which at the moment appears to be sufficient.

The second change in this commit is the fix of a formal error in the delimiter detection. There is one pattern which the function recognizes as a delimiter which consists of a line containing one unique character which is repeated more than six times in a row (such as `************` or `-------------`) . However, in the condition for the length of this pattern there is a misplaced parenthesis.

The third change is the automated assignment of a _ProjectId_ by R Studio. I am not sure this has any meaning. If this is a problem, one option would be to remove `searchbuildR.Rproj` from the git repo and listed in `.gitignore`.